### PR TITLE
Remove debug.keystore info

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ To run this sample, you'll need:
 
 ## Steps to Run the app
 
-> **Note:**
-> This sample ships with a default `redirect_uri` configured in the `AndroidManifest.xml`. In order for the default `redirect_uri` to work, this project must be built with the `debug.keystore` located in the `gradle/` directory. To configure signing in Android Studio, see [Sign Your App](https://developer.android.com/studio/publish/app-signing).
-
 ### Step 1: Clone the code
 
   From your shell or command line:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ To run this sample, you'll need:
 * An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/)
 * One or more user accounts in your Azure AD tenant.
 
-## Steps to Run the app
+## Steps to run the app
+
+As a convenience, this sample ships with a default `redirect_uri` preconfigured in the `AndroidManifest.xml` so that you don't have to first register your own app object. A `redirect_uri` is partly based on your app's signing key. The sample project is configured to sign using the included `debug.keystore` so that the provided `redirect_uri` will work.
 
 ### Step 1: Clone the code
 

--- a/README.md.orig
+++ b/README.md.orig
@@ -81,11 +81,14 @@ To run this sample, you'll need:
 * An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/)
 * One or more user accounts in your Azure AD tenant.
 
-## Steps to run the app
+## Steps to Run the app
 
-**Note:**
-As a convenience, this sample ships with a default `redirect_uri` preconfigured in the `AndroidManifest.xml` so that you don't have to first register your own app object. A `redirect_uri` is partly based on your app's signing key. The sample project is configured to sign using the included `debug.keystore` so that the provided `redirect_uri` will work.
+<<<<<<< HEAD
+> **Note:**
+> This sample ships with a default `redirect_uri` configured in the `AndroidManifest.xml`. In order for the default `redirect_uri` to work, this project must be built with the `debug.keystore` located in the `gradle/` directory. To configure signing in Android Studio, see [Sign Your App](https://developer.android.com/studio/publish/app-signing).
 
+=======
+>>>>>>> Remove debug.keystore info
 ### Step 1: Clone the code
 
   From your shell or command line:


### PR DESCRIPTION
We already config the test app to use debug.keystore inside the local gradle folder, instead of the default one (Thanks @shahzaibj for pointing out!), so this is no longer needed.

@TylerMSFT  and I agreed that we should drop the text around debug.keystore , both here and in the QuickStart, to prevent confusion.