### PR TITLE
Add sovereign cloud support

### DIFF
--- a/app/src/main/java/com/azuresamples/msalandroidapp/MSGraphRequestWrapper.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/MSGraphRequestWrapper.java
@@ -44,9 +44,18 @@ public class MSGraphRequestWrapper {
     private static final String TAG = MSGraphRequestWrapper.class.getSimpleName();
 
     /**
+     * See: https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+     */
+    public static final String MSGRAPH_RESOURCE_GLOBAL = "https://graph.microsoft.com";
+    public static final String MSGRAPH_RESOURCE_GERMANY = "https://graph.microsoft.de";
+    public static final String MSGRAPH_RESOURCE_CHINA = "https://microsoftgraph.chinacloudapi.cn";
+    public static final String MSGRAPH_RESOURCE_US_GOV_L4 = "https://graph.microsoft.us";
+    public static final String MSGRAPH_RESOURCE_US_GOV_L5_DOD = "https://dod-graph.microsoft.us";
+
+    /**
      * Use Volley to make an HTTP request with
-     *   1) a given MSGraph resource URL
-     *   2) an access token
+     * 1) a given MSGraph resource URL
+     * 2) an access token
      * to obtain MSGraph data.
      **/
     public static void callGraphAPIUsingVolley(@NonNull final Context context,

--- a/app/src/main/java/com/azuresamples/msalandroidapp/MultipleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/MultipleAccountModeFragment.java
@@ -296,6 +296,10 @@ public class MultipleAccountModeFragment extends Fragment {
 
     /**
      * Make an HTTP request to obtain MSGraph data
+     *
+     * The sample is using the global service cloud as a default.
+     * If you're developing an app for sovereign cloud users, please change the Microsoft Graph Resource URL accordingly.
+     * https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
      */
     private void callGraphAPI(final IAuthenticationResult authenticationResult) {
         MSGraphRequestWrapper.callGraphAPIUsingVolley(

--- a/app/src/main/java/com/azuresamples/msalandroidapp/MultipleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/MultipleAccountModeFragment.java
@@ -63,9 +63,6 @@ import java.util.List;
 public class MultipleAccountModeFragment extends Fragment {
     private static final String TAG = SingleAccountModeFragment.class.getSimpleName();
 
-    /* Azure AD v2 Configs */
-    final static String AUTHORITY = "https://login.microsoftonline.com/common";
-
     /* UI & Debugging Variables */
     Button removeAccountButton;
     Button callGraphApiInteractiveButton;
@@ -77,7 +74,6 @@ public class MultipleAccountModeFragment extends Fragment {
 
     /* Azure AD Variables */
     private IMultipleAccountPublicClientApplication mMultipleAccountApp;
-
     private List<IAccount> accountList;
 
     @Override
@@ -177,6 +173,8 @@ public class MultipleAccountModeFragment extends Fragment {
                     return;
                 }
 
+                final IAccount selectedAccount = accountList.get(accountListSpinner.getSelectedItemPosition());
+
                 /**
                  * Performs acquireToken without interrupting the user.
                  *
@@ -184,8 +182,8 @@ public class MultipleAccountModeFragment extends Fragment {
                  * (can be obtained via getAccount()).
                  */
                 mMultipleAccountApp.acquireTokenSilentAsync(getScopes(),
-                        accountList.get(accountListSpinner.getSelectedItemPosition()),
-                        AUTHORITY,
+                        selectedAccount,
+                        selectedAccount.getAuthority(),
                         getAuthSilentCallback());
             }
         });

--- a/app/src/main/java/com/azuresamples/msalandroidapp/MultipleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/MultipleAccountModeFragment.java
@@ -117,6 +117,13 @@ public class MultipleAccountModeFragment extends Fragment {
         logTextView = view.findViewById(R.id.txt_log);
         accountListSpinner = view.findViewById(R.id.account_list);
 
+        /**
+         * The sample is using the global service cloud as a default.
+         * If you're developing an app for sovereign cloud users, please change the Microsoft Graph Resource URL accordingly.
+         * https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+         */
+        graphResourceTextView.setText(MSGraphRequestWrapper.MSGRAPH_RESOURCE_GLOBAL + "/v1.0/me");
+
         removeAccountButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (mMultipleAccountApp == null) {

--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -125,6 +125,13 @@ public class SingleAccountModeFragment extends Fragment {
         currentUserTextView = view.findViewById(R.id.current_user);
         deviceModeTextView = view.findViewById(R.id.device_mode);
 
+        /**
+         * The sample is using the global service cloud as a default.
+         * If you're developing an app for sovereign cloud users, please change the Microsoft Graph Resource URL accordingly.
+         * https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+         */
+        graphResourceTextView.setText(MSGraphRequestWrapper.MSGRAPH_RESOURCE_GLOBAL + "/v1.0/me");
+
         signInButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (mSingleAccountApp == null) {
@@ -202,7 +209,7 @@ public class SingleAccountModeFragment extends Fragment {
 
         /**
          * The account may have been removed from the device (if broker is in use).
-         * 
+         *
          * In shared device mode, the account might be signed in/out by other apps while this app is not in focus.
          * Therefore, we want to update the account state by invoking loadAccount() here.
          */

--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -65,9 +65,6 @@ import org.json.JSONObject;
 public class SingleAccountModeFragment extends Fragment {
     private static final String TAG = SingleAccountModeFragment.class.getSimpleName();
 
-    /* Azure AD v2 Configs */
-    final static String AUTHORITY = "https://login.microsoftonline.com/common";
-
     /* UI & Debugging Variables */
     Button signInButton;
     Button signOutButton;
@@ -81,6 +78,7 @@ public class SingleAccountModeFragment extends Fragment {
 
     /* Azure AD Variables */
     private ISingleAccountPublicClientApplication mSingleAccountApp;
+    private IAccount mAccount;
 
     @Override
     public View onCreateView(LayoutInflater inflater,
@@ -149,8 +147,9 @@ public class SingleAccountModeFragment extends Fragment {
                 mSingleAccountApp.signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
                     @Override
                     public void onSignOut() {
-                        updateUI(null);
-                        performOperationOnSignOut();
+                        mAccount = null;
+                        updateUI();
+                        showToastOnSignOut();
                     }
 
                     @Override
@@ -191,7 +190,7 @@ public class SingleAccountModeFragment extends Fragment {
                  * Once you've signed the user in,
                  * you can perform acquireTokenSilent to obtain resources without interrupting the user.
                  */
-                mSingleAccountApp.acquireTokenSilentAsync(getScopes(), AUTHORITY, getAuthSilentCallback());
+                mSingleAccountApp.acquireTokenSilentAsync(getScopes(), mAccount.getAuthority(), getAuthSilentCallback());
             }
         });
 
@@ -230,14 +229,15 @@ public class SingleAccountModeFragment extends Fragment {
             @Override
             public void onAccountLoaded(@Nullable IAccount activeAccount) {
                 // You can use the account data to update your UI or your app database.
-                updateUI(activeAccount);
+                mAccount = activeAccount;
+                updateUI();
             }
 
             @Override
             public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
                 if (currentAccount == null) {
                     // Perform a cleanup task as the signed-in account changed.
-                    performOperationOnSignOut();
+                    showToastOnSignOut();
                 }
             }
 
@@ -294,7 +294,8 @@ public class SingleAccountModeFragment extends Fragment {
                 Log.d(TAG, "ID Token: " + authenticationResult.getAccount().getClaims().get("id_token"));
 
                 /* Update account */
-                updateUI(authenticationResult.getAccount());
+                mAccount = authenticationResult.getAccount();
+                updateUI();
 
                 /* call graph */
                 callGraphAPI(authenticationResult);
@@ -372,13 +373,13 @@ public class SingleAccountModeFragment extends Fragment {
     /**
      * Updates UI based on the current account.
      */
-    private void updateUI(@Nullable final IAccount account) {
-        if (account != null) {
+    private void updateUI() {
+        if (mAccount != null) {
             signInButton.setEnabled(false);
             signOutButton.setEnabled(true);
             callGraphApiInteractiveButton.setEnabled(true);
             callGraphApiSilentButton.setEnabled(true);
-            currentUserTextView.setText(account.getUsername());
+            currentUserTextView.setText(mAccount.getUsername());
         } else {
             signInButton.setEnabled(true);
             signOutButton.setEnabled(false);
@@ -393,7 +394,7 @@ public class SingleAccountModeFragment extends Fragment {
     /**
      * Updates UI when app sign out succeeds
      */
-    private void performOperationOnSignOut() {
+    private void showToastOnSignOut() {
         final String signOutText = "Signed Out.";
         currentUserTextView.setText("");
         Toast.makeText(getContext(), signOutText, Toast.LENGTH_SHORT)

--- a/app/src/main/res/layout/fragment_multiple_account_mode.xml
+++ b/app/src/main/res/layout/fragment_multiple_account_mode.xml
@@ -85,7 +85,6 @@
                         android:id="@+id/msgraph_url"
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"
-                        android:text="https://graph.microsoft.com/v1.0/me"
                         android:textSize="12sp" />
                 </LinearLayout>
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_single_account_mode.xml
+++ b/app/src/main/res/layout/fragment_single_account_mode.xml
@@ -85,7 +85,6 @@
                         android:id="@+id/msgraph_url"
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"
-                        android:text="https://graph.microsoft.com/v1.0/me"
                         android:textSize="12sp" />
                 </LinearLayout>
             </LinearLayout>

--- a/app/src/main/res/raw/auth_config_multiple_account.json
+++ b/app/src/main/res/raw/auth_config_multiple_account.json
@@ -4,6 +4,7 @@
   "redirect_uri" : "msauth://com.azuresamples.msalandroidapp/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "account_mode" : "MULTIPLE",
   "broker_redirect_uri_registered": true,
+  "multiple_clouds_supported": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/app/src/main/res/raw/auth_config_single_account.json
+++ b/app/src/main/res/raw/auth_config_single_account.json
@@ -4,6 +4,7 @@
   "redirect_uri" : "msauth://com.azuresamples.msalandroidapp/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "account_mode" : "SINGLE",
   "broker_redirect_uri_registered": true,
+  "multiple_clouds_supported": true,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
- Add multiple_clouds_supported in the json file.
    - We will also need to call this out in the quickstart.
- Use account's (home) authority instead of the hardcoded common for acquireTokenSilent()
   - We've discussed on making this change in MSAL, but that will be out with the next release.
- We'll still need to call out in the Quickstart that the devs have to pick the right MSGraph Resource URI ( see https://docs.microsoft.com/en-us/graph/deployments)