### PR TITLE
Add workaround for Quickstart

### DIFF
--- a/AppCreationScripts/apps.json
+++ b/AppCreationScripts/apps.json
@@ -50,7 +50,7 @@
            {
              "settingFile": "/app/src/main/AndroidManifest.xml",
              "replaceTokens": {
-                "packageName": "com.azuresamples.msalandroidapp",
+                "packageName": "android:host=\"com.azuresamples.msalandroidapp\"",
                 "keyHash": "1wIqXSqBj7w+h11ZifsnqwgyKrY="
               }
            },


### PR DESCRIPTION
This is to make sure we're not actually replacing the package name (under <manifest>).

This means that the sample will not work with Broker app with the Quickstart. @hamiltonha  we should call that out for now.

We'll revert this back once the portal is able to move files around. This is because changing package name under <manifest> means that we have to change the package of .java files.