### PR TITLE
Adding a button for signInAgain() to SAPCA

### DIFF
--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -172,7 +172,7 @@ public class SingleAccountModeFragment extends Fragment {
 
                 /**
                  * If acquireTokenSilent() returns an error that requires an interaction (MsalUiRequiredException),
-                 * invoke acquireToken() to have the user resolve the interrupt interactively.
+                 * invoke signInAgain() to have the user resolve the interrupt interactively.
                  *
                  * Some example scenarios are
                  *  - password change

--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -44,7 +44,6 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
-import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.SilentAuthenticationCallback;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -68,7 +67,6 @@ public class SingleAccountModeFragment extends Fragment {
 
     /* UI & Debugging Variables */
     Button signInButton;
-    Button signInAgainButton;
     Button signOutButton;
     Button callGraphApiInteractiveButton;
     Button callGraphApiSilentButton;
@@ -118,7 +116,6 @@ public class SingleAccountModeFragment extends Fragment {
      */
     private void initializeUI(@NonNull final View view) {
         signInButton = view.findViewById(R.id.btn_signIn);
-        signInAgainButton = view.findViewById(R.id.btn_signinagain);
         signOutButton = view.findViewById(R.id.btn_removeAccount);
         callGraphApiInteractiveButton = view.findViewById(R.id.btn_callGraphInteractively);
         callGraphApiSilentButton = view.findViewById(R.id.btn_callGraphSilently);
@@ -138,13 +135,6 @@ public class SingleAccountModeFragment extends Fragment {
                 }
 
                 mSingleAccountApp.signIn(getActivity(), null, getScopes(), getAuthInteractiveCallback());
-            }
-        });
-
-        signInAgainButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mSingleAccountApp.signInAgain(getActivity(), getScopes(), Prompt.LOGIN, getAuthInteractiveCallback());
             }
         });
 

--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -44,6 +44,7 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
+import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.SilentAuthenticationCallback;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -67,6 +68,7 @@ public class SingleAccountModeFragment extends Fragment {
 
     /* UI & Debugging Variables */
     Button signInButton;
+    Button signInAgainButton;
     Button signOutButton;
     Button callGraphApiInteractiveButton;
     Button callGraphApiSilentButton;
@@ -116,6 +118,7 @@ public class SingleAccountModeFragment extends Fragment {
      */
     private void initializeUI(@NonNull final View view) {
         signInButton = view.findViewById(R.id.btn_signIn);
+        signInAgainButton = view.findViewById(R.id.btn_signinagain);
         signOutButton = view.findViewById(R.id.btn_removeAccount);
         callGraphApiInteractiveButton = view.findViewById(R.id.btn_callGraphInteractively);
         callGraphApiSilentButton = view.findViewById(R.id.btn_callGraphSilently);
@@ -135,6 +138,13 @@ public class SingleAccountModeFragment extends Fragment {
                 }
 
                 mSingleAccountApp.signIn(getActivity(), null, getScopes(), getAuthInteractiveCallback());
+            }
+        });
+
+        signInAgainButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mSingleAccountApp.signInAgain(getActivity(), getScopes(), Prompt.LOGIN, getAuthInteractiveCallback());
             }
         });
 

--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -170,6 +170,15 @@ public class SingleAccountModeFragment extends Fragment {
                     return;
                 }
 
+                /**
+                 * If acquireTokenSilent() returns an error that requires an interaction (MsalUiRequiredException),
+                 * invoke acquireToken() to have the user resolve the interrupt interactively.
+                 *
+                 * Some example scenarios are
+                 *  - password change
+                 *  - the resource you're acquiring a token for has a stricter set of requirement than your Single Sign-On refresh token.
+                 *  - you're introducing a new scope which the user has never consented for.
+                 */
                 mSingleAccountApp.signInAgain(getActivity(), getScopes(), Prompt.LOGIN, getAuthInteractiveCallback());
             }
         });

--- a/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
+++ b/app/src/main/java/com/azuresamples/msalandroidapp/SingleAccountModeFragment.java
@@ -44,6 +44,7 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
+import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.SilentAuthenticationCallback;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -67,8 +68,8 @@ public class SingleAccountModeFragment extends Fragment {
 
     /* UI & Debugging Variables */
     Button signInButton;
+    Button signInAgainButton;
     Button signOutButton;
-    Button callGraphApiInteractiveButton;
     Button callGraphApiSilentButton;
     TextView scopeTextView;
     TextView graphResourceTextView;
@@ -117,7 +118,7 @@ public class SingleAccountModeFragment extends Fragment {
     private void initializeUI(@NonNull final View view) {
         signInButton = view.findViewById(R.id.btn_signIn);
         signOutButton = view.findViewById(R.id.btn_removeAccount);
-        callGraphApiInteractiveButton = view.findViewById(R.id.btn_callGraphInteractively);
+        signInAgainButton = view.findViewById(R.id.btn_signInAgain);
         callGraphApiSilentButton = view.findViewById(R.id.btn_callGraphSilently);
         scopeTextView = view.findViewById(R.id.scope);
         graphResourceTextView = view.findViewById(R.id.msgraph_url);
@@ -163,22 +164,13 @@ public class SingleAccountModeFragment extends Fragment {
             }
         });
 
-        callGraphApiInteractiveButton.setOnClickListener(new View.OnClickListener() {
+        signInAgainButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (mSingleAccountApp == null) {
                     return;
                 }
 
-                /**
-                 * If acquireTokenSilent() returns an error that requires an interaction (MsalUiRequiredException),
-                 * invoke acquireToken() to have the user resolve the interrupt interactively.
-                 *
-                 * Some example scenarios are
-                 *  - password change
-                 *  - the resource you're acquiring a token for has a stricter set of requirement than your Single Sign-On refresh token.
-                 *  - you're introducing a new scope which the user has never consented for.
-                 */
-                mSingleAccountApp.acquireToken(getActivity(), getScopes(), getAuthInteractiveCallback());
+                mSingleAccountApp.signInAgain(getActivity(), getScopes(), Prompt.LOGIN, getAuthInteractiveCallback());
             }
         });
 
@@ -380,13 +372,13 @@ public class SingleAccountModeFragment extends Fragment {
         if (mAccount != null) {
             signInButton.setEnabled(false);
             signOutButton.setEnabled(true);
-            callGraphApiInteractiveButton.setEnabled(true);
+            signInAgainButton.setEnabled(true);
             callGraphApiSilentButton.setEnabled(true);
             currentUserTextView.setText(mAccount.getUsername());
         } else {
             signInButton.setEnabled(true);
             signOutButton.setEnabled(false);
-            callGraphApiInteractiveButton.setEnabled(false);
+            signInAgainButton.setEnabled(false);
             callGraphApiSilentButton.setEnabled(false);
             currentUserTextView.setText("None");
         }

--- a/app/src/main/res/layout/fragment_single_account_mode.xml
+++ b/app/src/main/res/layout/fragment_single_account_mode.xml
@@ -31,30 +31,30 @@
                 <TextView
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="3"
                     android:layout_gravity="center_vertical"
-                    android:textStyle="bold"
-                    android:text="Scope" />
+                    android:layout_weight="3"
+                    android:text="Scope"
+                    android:textStyle="bold" />
 
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_weight="7">
+                    android:layout_weight="7"
+                    android:orientation="vertical">
 
                     <EditText
                         android:id="@+id/scope"
-                        android:layout_height="wrap_content"
                         android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
                         android:text="user.read"
                         android:textSize="12sp" />
 
                     <TextView
-                        android:layout_height="wrap_content"
                         android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
                         android:paddingLeft="5dp"
                         android:text="Type in scopes delimited by space"
-                        android:textSize="10sp"  />
+                        android:textSize="10sp" />
 
                 </LinearLayout>
             </LinearLayout>
@@ -70,21 +70,21 @@
                 <TextView
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="3"
                     android:layout_gravity="center_vertical"
-                    android:textStyle="bold"
-                    android:text="MSGraph Resource URL" />
+                    android:layout_weight="3"
+                    android:text="MSGraph Resource URL"
+                    android:textStyle="bold" />
 
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_weight="7">
+                    android:layout_weight="7"
+                    android:orientation="vertical">
 
                     <EditText
                         android:id="@+id/msgraph_url"
-                        android:layout_height="wrap_content"
                         android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
                         android:textSize="12sp" />
                 </LinearLayout>
             </LinearLayout>
@@ -101,15 +101,15 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="3"
-                    android:textStyle="bold"
-                    android:text="Signed-in user" />
+                    android:text="Signed-in user"
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/current_user"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="5dp"
                     android:layout_weight="7"
+                    android:paddingLeft="5dp"
                     android:text="None" />
             </LinearLayout>
 
@@ -125,15 +125,15 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="3"
-                    android:textStyle="bold"
-                    android:text="Device mode" />
+                    android:text="Device mode"
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/device_mode"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="5dp"
                     android:layout_weight="7"
+                    android:paddingLeft="5dp"
                     android:text="None" />
             </LinearLayout>
 
@@ -151,16 +151,16 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
                     android:gravity="center"
-                    android:text="Sign In"/>
+                    android:text="Sign In" />
 
                 <Button
                     android:id="@+id/btn_removeAccount"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
+                    android:enabled="false"
                     android:gravity="center"
-                    android:text="Sign Out"
-                    android:enabled="false"/>
+                    android:text="Sign Out" />
             </LinearLayout>
 
 
@@ -175,16 +175,30 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
-                    android:text="Get Graph Data Interactively"
-                    android:enabled="false"/>
+                    android:enabled="false"
+                    android:text="Get Graph Data Interactively" />
 
                 <Button
                     android:id="@+id/btn_callGraphSilently"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
-                    android:text="Get Graph Data Silently"
-                    android:enabled="false"/>
+                    android:enabled="false"
+                    android:text="Get Graph Data Silently" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:weightSum="10">
+
+                <Button
+                    android:id="@+id/btn_signinagain"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="5"
+                    android:text="Sign In Again" />
             </LinearLayout>
 
 

--- a/app/src/main/res/layout/fragment_single_account_mode.xml
+++ b/app/src/main/res/layout/fragment_single_account_mode.xml
@@ -31,30 +31,30 @@
                 <TextView
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
                     android:layout_weight="3"
-                    android:text="Scope"
-                    android:textStyle="bold" />
+                    android:layout_gravity="center_vertical"
+                    android:textStyle="bold"
+                    android:text="Scope" />
 
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="7"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:layout_weight="7">
 
                     <EditText
                         android:id="@+id/scope"
-                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
                         android:text="user.read"
                         android:textSize="12sp" />
 
                     <TextView
-                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
                         android:paddingLeft="5dp"
                         android:text="Type in scopes delimited by space"
-                        android:textSize="10sp" />
+                        android:textSize="10sp"  />
 
                 </LinearLayout>
             </LinearLayout>
@@ -70,21 +70,21 @@
                 <TextView
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
                     android:layout_weight="3"
-                    android:text="MSGraph Resource URL"
-                    android:textStyle="bold" />
+                    android:layout_gravity="center_vertical"
+                    android:textStyle="bold"
+                    android:text="MSGraph Resource URL" />
 
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="7"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:layout_weight="7">
 
                     <EditText
                         android:id="@+id/msgraph_url"
-                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
                         android:textSize="12sp" />
                 </LinearLayout>
             </LinearLayout>
@@ -101,15 +101,15 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="3"
-                    android:text="Signed-in user"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    android:text="Signed-in user" />
 
                 <TextView
                     android:id="@+id/current_user"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="7"
                     android:paddingLeft="5dp"
+                    android:layout_weight="7"
                     android:text="None" />
             </LinearLayout>
 
@@ -125,15 +125,15 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="3"
-                    android:text="Device mode"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    android:text="Device mode" />
 
                 <TextView
                     android:id="@+id/device_mode"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="7"
                     android:paddingLeft="5dp"
+                    android:layout_weight="7"
                     android:text="None" />
             </LinearLayout>
 
@@ -151,16 +151,16 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
                     android:gravity="center"
-                    android:text="Sign In" />
+                    android:text="Sign In"/>
 
                 <Button
                     android:id="@+id/btn_removeAccount"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
-                    android:enabled="false"
                     android:gravity="center"
-                    android:text="Sign Out" />
+                    android:text="Sign Out"
+                    android:enabled="false"/>
             </LinearLayout>
 
 
@@ -175,30 +175,16 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
-                    android:enabled="false"
-                    android:text="Get Graph Data Interactively" />
+                    android:text="Get Graph Data Interactively"
+                    android:enabled="false"/>
 
                 <Button
                     android:id="@+id/btn_callGraphSilently"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
-                    android:enabled="false"
-                    android:text="Get Graph Data Silently" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:weightSum="10">
-
-                <Button
-                    android:id="@+id/btn_signinagain"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="5"
-                    android:text="Sign In Again" />
+                    android:text="Get Graph Data Silently"
+                    android:enabled="false"/>
             </LinearLayout>
 
 

--- a/app/src/main/res/layout/fragment_single_account_mode.xml
+++ b/app/src/main/res/layout/fragment_single_account_mode.xml
@@ -171,11 +171,11 @@
                 android:orientation="horizontal">
 
                 <Button
-                    android:id="@+id/btn_callGraphInteractively"
+                    android:id="@+id/btn_signInAgain"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="5"
-                    android:text="Get Graph Data Interactively"
+                    android:text="Sign in Again"
                     android:enabled="false"/>
 
                 <Button


### PR DESCRIPTION
Adds a new button to demonstrate `signInAgain()`. 

Demo below shows that account name cannot be changed once a user has already signed in
![disallow_name_change](https://user-images.githubusercontent.com/990063/89075139-5cfafe80-d332-11ea-8c0c-267de8729209.gif)
