### PR TITLE
Accept msal version as command line parameter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 
 def msalVersion = "2.+"
 
+if (project.hasProperty("distMsalVersion")) {
+    msalVersion = distMsalVersion
+}
+
 allprojects {
     repositories {
         mavenCentral()


### PR DESCRIPTION
To facilitate creating Azure Sample APK with specific MSAL version during releases

Related: https://github.com/AzureAD/android-complete/pull/63