### PR TITLE
bumping to java version 8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,15 @@ android {
             keyPassword 'android'
         }
     }
+
+    // bumping up to Java Version 8 due to the addition of the YubiKit SDK,
+    // which depends on Version 8.
+    // Host apps that use a library with version 8 must also be able to handle version 8 as well.
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     buildTypes {
         release {
             signingConfig signingConfigs.release

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,10 +9,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <!-- Adding configChanges flags to MainActivity in order to make sure the app doesn't behave erratically when a YubiKey is plugged in -->
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout|keyboard">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR will bump AzureSample up from Java version 7 to 8.  In order to incorporate the YubiKit SDK (which is integral to smartcard Certificate Based Authentication, a new feature we are adding in the next two quarters), any host apps that will use our libraries (which will all have YubiKit incorporated) must support Java 8. 
    * For more information on why these compileOptions cannot just be handled by libraries, see these posts: 
        * https://stackoverflow.com/questions/48099802/android-desugar-classes-in-aar-package
        * https://stackoverflow.com/questions/49521808/compile-java-8-android-library-to-be-consumed-in-java-7
* This PR also adds `configChanges` flags in the manifest for the Main Activity in order to prevent erratic behavior when a YubiKey is plugged in. When a configuration change occurs, Android's default handling is to restart the current activity, which will introduce many errors if the behavior is not accounted for. Adding these flags gives us control over what happens when a config change is sensed. In this case, we want to make sure nothing occurs when a YubiKey is plugged in.
    * The main two flags that fixed erratic behavior were `keyboard` and `keyboardHidden`. I noted that the app crashes when the YubiKey is plugged in and other configuration changes happen (such as an orientation change), so to be safe, I also added in the remaining flags that we already have for many of our activities within common. 
    * For more information about `configChanges`: https://developer.android.com/guide/topics/resources/runtime-changes#HandlingTheChange
* The main PR driving these changes: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```
Our customers will need to be notified that they will need to:
* Handle Java Version 8 in their apps.
* Not crash in their main activities if a YubiKey is plugged in (the changes needed for this could vary among host apps).  

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
This change is being made in preparation for the addition of smartcard Certificate Based Authentication (CBA).

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
(Taken from the main common PR that adds YubiKit SDK: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729)

Current tests in _Cert-Based Auth (TLS Challenge)_ in the manual test plans cover testing to make sure that on-device CBA still works with `ClientCertAuthChallengeHandler`. Detailed manual tests will be added to the same category once Smartcard CBA is fully complete.
When a YubiKey is plugged in, an alertDialog pops up that asks the user for permission to access the key. This is implemented by the YubiKit SDK. If the user accepts, the YubiKitManager now has access to the key. If the user denies, the YubiKitManager ignores the key.
To make sure that the YubiKey was being detected by the YubiKit SDK, I plugged in the YubiKey at various stages of the CBA flow while testing AzureSample, with and without BrokerHost:

- Plug in before clicking "Acquire Token"
    1. Plug in YubiKey.
    2. No logs that device was connected initially.
    3. Click "Acquire Token".
    4. Should be prompted by AlertDialog to authorize connection with YubiKey. Click "Accept".
    5. Log should show that device was connected.
    6. Finish on-device CBA.
    7. Upon successful login and return to AzureSample, log should show that device was disconnected.
- Plug in YubiKey after clicking "AcquireToken" (while WebView is showing)
    1. Click "Acquire Token".
    2. Once WebView is visible, plug in YubiKey.
    3. Should be prompted by AlertDialog to authorize connection with YubiKey. Click "Accept".
    4. Log should show that device was connected.
    5. Finish on-device CBA.
    6. Upon successful login and return to AzureSample, log should show that device was disconnected.
 - Plug in YubiKey after clicking "AcquireToken", and unplug while WebView is showing.
    1. Click "Acquire Token".
    2. Once WebView is visible, plug in YubiKey.
    3. Should be prompted by AlertDialog to authorize connection with YubiKey. Click "Accept".
    4. Log should show that device was connected.
    5. Unplug YubiKey.
    6. Log should show that device was disconnected.
    7. Finish on-device CBA.
    8. CBA should finish successfully with no crashes.

Another alternative flow that could be included in each of the scenarios above is denying connection with YubiKey in AlertDialog (No logs that show device is connected or disconnected). Due to the addition of the `keyboard` and `keyboardHidden` to Activity `configChanges` in the Manifests, none of the scenarios above should result in crashing. 


## What to Check
Verify that the following are valid
* The app does not crash at any point in which the YubiKey is plugged in.
* When authenticating via WebView, if the YubiKey was recently plugged in, a dialog should pop up that asks for permission to connect.
* The above checks should still be valid if brokerHost is installed.

## Other Information
<!-- Add any other helpful information that may be needed here. -->