### PR TITLE
Enable multidex for apps with over 64K methods

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
     }
     signingConfigs {
         debug {


### PR DESCRIPTION
Issue : Build for azure sample is failing after consuming latest MSAL version.
below is the error

> A failure occurred while executing com.android.build.gradle.internal.tasks.DexMergingTaskDelegate
   > There was a failure while executing work items
      > A failure occurred while executing com.android.build.gradle.internal.tasks.DexMergingWorkAction
         > com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives: 
           The number of method references in a .dex file cannot exceed 64K.


Fix : Enable multidex for apps with over 64K methods