### PR TITLE
Update CIAM Fragment to match new CIAM Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ This class is used to support CIAM users and confirming that the user can authen
 This fragment's `acquireToken`, `getAccounts`, `acquireTokenSilentAsync`, and `removeAccount` are similar to those found in `MultipleAccountModeFragment`, but updated to use non-deprecated methods.
 
 > **Note:**
-> This fragment reads configuration information from `auth_config_ciam.json`. This JSON uses a tenant that is in-accessible to external developers. To get this fragment of the sample to work, you will have to manual update the `authority_url` field to point towards your CIAM tenant. The url should look like this: "https://login.microsoftonline.com/YOUR.TENANT/"
+ This fragment reads configuration information from `auth_config_ciam.json`. To get this fragment of the sample to work, you will have to manually input the `client_id` and `authority_url` fields to point towards your CIAM tenant (reference the [Register your Own Application section](#register-your-own-application-optional) for more information). The `authority_url` should look like this: "https://TENANT_NAME.ciamlogin.com/TENANT_NAME.onmicrosoft.com/". The authority type should remain as `CIAM`.
 
 ## Feedback, Community Help, and Support
 

--- a/app/src/main/res/layout/fragment_ciam_mode.xml
+++ b/app/src/main/res/layout/fragment_ciam_mode.xml
@@ -46,7 +46,7 @@
                         android:id="@+id/scope"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="https://substrate.office.com/profile//User.Read"
+                        android:text="user.read"
                         android:textSize="12sp" />
 
                     <TextView

--- a/app/src/main/res/raw/auth_config_ciam.json
+++ b/app/src/main/res/raw/auth_config_ciam.json
@@ -7,7 +7,7 @@
   "authorities" : [
     {
       "type": "CIAM",
-      "authority_url": "https://TENANT_DOMAIN.ciamlogin.com/TENANT_DOMAIN.onmicrosoft.com/"
+      "authority_url": "https://TENANT_NAME.ciamlogin.com/TENANT_NAME.onmicrosoft.com/"
     }
   ]
 }

--- a/app/src/main/res/raw/auth_config_ciam.json
+++ b/app/src/main/res/raw/auth_config_ciam.json
@@ -1,13 +1,13 @@
 {
-  "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
+  "client_id" : "CLIENT_ID",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.azuresamples.msalandroidapp/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "account_mode" : "MULTIPLE",
   "broker_redirect_uri_registered": true,
   "authorities" : [
     {
-      "type": "AAD",
-      "authority_url": "https://login.microsoftonline.com/msidlabciam1.onmicrosoft.com/"
+      "type": "CIAM",
+      "authority_url": "https://TENANT_DOMAIN.ciamlogin.com/TENANT_DOMAIN.onmicrosoft.com/"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
This PR updates the CIAM fragment to match the latest CIAM guidelines. The old config file was referencing a now deleted tenant, which was causes failures for internal devs, now devs must enter their own client id and authority url from their trial ciam tenant, this removes the expectation that this part of the sample will work entirely out of the box without any changes (all that is needed is an update to the config file).

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Ran AcquireToken and AcquireTokenSilent locally

## What to Check
N/A

## Other Information
Also updated readme to reflect the new config requirement.