### PR TITLE
Target, compile SDK, AGP and gradle version increase

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
     buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
         applicationId "com.azuresamples.msalandroidapp"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
     // Host apps that use a library with version 8 must also be able to handle version 8 as well.
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,7 @@ allprojects {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
         applicationId "com.azuresamples.msalandroidapp"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -57,7 +56,7 @@ android {
     // Host apps that use a library with version 8 must also be able to handle version 8 as well.
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 }
 
 android {
-    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
+    compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
         applicationId "com.azuresamples.msalandroidapp"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         </activity>
         <activity
             android:name="com.microsoft.identity.client.BrowserTabActivity"
-            android:exported="false"
+            android:exported="true"
             tools:replace="android:exported">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.azuresamples.msalandroidapp">
 
     <application
@@ -14,14 +15,18 @@
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar"
-            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout|keyboard">
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout|keyboard"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
+        <activity
+            android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="false"
+            tools:replace="android:exported">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,11 +5,10 @@ ext {
     automationAppMinSDKVersion = 21
     targetSdkVersion = 34
     compileSdkVersion = 34
-    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '4.0.2'
+    gradleVersion = '7.4.2'
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,8 +3,9 @@ ext {
     // SDK
     minSdkVersion = 16
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 34
+    compileSdkVersion = 34
+    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,7 +3,7 @@ ext {
     // SDK
     minSdkVersion = 16
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 34
+    targetSdkVersion = 33
     compileSdkVersion = 34
     buildToolsVersion = "28.0.3"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip


### PR DESCRIPTION
1. Target sdk version changed to 33
2. Compile sdk version changed to 34
3. AGP version changed to 7.4.2
4. Gradle distribution url changed to 7.5

After changing above versions, I had to update other dependencies for compatibility

1. Powerlift version changed to 1.0.3
2. Bouncy castle version changed to 1.69
3. robolectric version to 4.9
4. Also, with new gradle versions, some of the properties used in gradle were deprecated (naming conventions changed). So, made those changes
5. With targetSDK changes, we should not be having a package name in AndroidManifest.xml.. instead, should add a namespace property in build.gradle. https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents