### PR TITLE
Add credScan suppression file

### DIFF
--- a/config/credscan/suppression.json
+++ b/config/credscan/suppression.json
@@ -1,0 +1,4 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": []
+}   

--- a/config/credscan/suppression.json
+++ b/config/credscan/suppression.json
@@ -1,4 +1,9 @@
 {
     "tool": "Credential Scanner",
-    "suppressions": []
+    "suppressions": [
+    {
+        "file": "gradle/debug.keystore", 
+        "_justification": "Not production keystore"
+    }
+    ]
 }   


### PR DESCRIPTION
# Why 
In order to be compliant with EO we move the production pipelines to 1ES Pipeline Templates, this templates auto-inject some sdl tasks like credscan, that scan all the repos used.
In this case credscan found a couple of 'vulnerabilities' that blocks the pipeline, in order to ignore these false alarms, we need to include this file.